### PR TITLE
80% appendに変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,11 +28,9 @@ class ProductScreen extends ConsumerWidget {
     final controller = ScrollController();
 
     controller.addListener(() {
-      if (controller.position.atEdge) {
-        final isBottom = controller.position.pixels == controller.position.maxScrollExtent;
-        if (isBottom) {
-          notifier.append();
-        }
+      final scrollPercentage = controller.position.pixels / controller.position.maxScrollExtent;
+      if (scrollPercentage >= 0.8) {
+        notifier.append();
       }
     });
 

--- a/lib/product_provider.dart
+++ b/lib/product_provider.dart
@@ -47,19 +47,19 @@ class AsyncProduct extends _$AsyncProduct {
   Future<void> append() async {
     // Notifierを使った場合、`state`という変数しか再代入できないようになっています。
     // requireValueは、AsyncValueの中身を取得するための変数。初期化されていない場合などはエラー
-    state = const AsyncLoading();
     final current = state.requireValue;
     final next = await fetchProducts();
     // currentとnextを結合すると、要素が全部連結された配列を返します。
     // [1,2,3,4] + [1,2,3,4] = [1,2,3,4,1,2,3,4]
     final result = current + next;
     // stateには、AsyncValueという型が入っています。AsyncValueは、AsyncLoading, AsyncData, AsyncErrorの3つの状態を持ちます。
-    state = AsyncData(result);
+    state = const AsyncLoading();
+    state = AsyncValue.data(result); // AsyncData(result)
   }
 }
 
 Future<List<Map<String, dynamic>>> fetchProducts() async {
-  return Future.delayed(const Duration(seconds: 2), () {
+  return Future.delayed(const Duration(seconds: 1), () {
     return [
       {
         'name': 'Apple iPhone 14 Pro',


### PR DESCRIPTION
以下いただいた指摘を修正

 - controller.position.atEdge は冗長。isBottomと答え一緒。
   -  controller.position.atEdgeを削除し、isBottomのみに修正しました。

 - いちばん最後までスクロールする場合ではなく、例えば. maxScrollExtent の 80%行ったら読むという実装に変えてみてほしい。このコードだと危ない。appendが何度も呼ばれる可能性がある。
   -  controller.position.pixelsで取得した位置に対してcontroller.position.maxScrollExtent(スクロールマックス値)を割り、0.8であればtrueとするようにした。

 - AsyncValueの動きを掴むためにLoadingを出したけど、無限スクロールの実装で画面全体を Loadingに切り替えることはしない。画面全体が再ロード煮切りかるのは極めてうっとおしい。
   - delayed無くすと読み込む瞬間がわからなくなるので一旦1秒で残す

